### PR TITLE
Fix the example for Subscribe function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ func main() {
 
     // 事件订阅
     event.Subscribe(&TestEvent{})
-    event.Subscribe(TestEventPrefix{})
+    event.Subscribe(&TestEventPrefix{})
     event.Subscribe(&TestEventSubscribe{})
 
     // 事件订阅触发


### PR DESCRIPTION
I think we should pass the pointer to the `TestEventPrefix` to the `subscribe` function, otherwise the event will not be fired.